### PR TITLE
Update links in docs to new org location

### DIFF
--- a/docs/contributing/development_environment.md
+++ b/docs/contributing/development_environment.md
@@ -14,7 +14,7 @@ Also, if you haven't done so already, please review the [Testing on Your Own Acc
 
 ## Make a local working copy of the project
 
-First, fork the `django-simple-deploy` project on GitHub. If you haven't done this before, look for the Fork button in the upper right corner of the project's [home page](https://github.com/ehmatthes/django-simple-deploy/). This will copy the main branch of the project to a new repo under your account.
+First, fork the `django-simple-deploy` project on GitHub. If you haven't done this before, look for the Fork button in the upper right corner of the project's [home page](https://github.com/django-simple-deploy/django-simple-deploy/). This will copy the main branch of the project to a new repo under your account.
 
 Next, clone your Github (replace `<username>` with your username):
 
@@ -27,7 +27,7 @@ Add an `upstream` remote, then configure `git` to pull `main` from `upstream` an
 
 ```bash
 $ cd django-simple-deploy
-$ git remote add upstream https://github.com/ehmatthes/django-simple-deploy
+$ git remote add upstream https://github.com/django-simple-deploy/django-simple-deploy
 $ git config branch.main.remote upstream
 $ git remote set-url --push upstream git@github.com:<your-username>/django-simple-deploy.git
 ```
@@ -38,7 +38,7 @@ You can verify that `git` is configured correctly by running:
 $ git remote -v
 origin  git@github.com:<username>/django-simple-deploy.git (fetch)
 origin  git@github.com:<username>/django-simple-deploy.git (push)
-upstream        https://github.com/ehmatthes/django-simple-deploy (fetch)
+upstream        https://github.com/django-simple-deploy/django-simple-deploy (fetch)
 upstream        git@github.com:<username>/django-simple-deploy.git (push)
 
 $ git config branch.main.remote
@@ -233,7 +233,7 @@ If you're interested in running the unit tests, please refer to [Unit tests](../
 
 ## Running integration tests
 
-The integration tests have been critical in developing the project to this point. That said, they are in need of restructuring as well. If you want to understand the current state of the integration tests, see the [old documentation](https://github.com/ehmatthes/django-simple-deploy/blob/main/old_docs/integration_tests.md) as well.
+The integration tests have been critical in developing the project to this point. That said, they are in need of restructuring as well. If you want to understand the current state of the integration tests, see the [old documentation](https://github.com/django-simple-deploy/django-simple-deploy/blob/main/old_docs/integration_tests.md) as well.
 
 ## Ongoing work
 
@@ -268,4 +268,4 @@ $ python build_dev_env.py --pkg-manager [req_txt | poetry | pipenv] --target [de
 
 ## Closing thoughts
 
-This is a rapidly evolving project. Please feel free to open an [issue](https://github.com/ehmatthes/django-simple-deploy/issues/new/choose) or a [discussion](https://github.com/ehmatthes/django-simple-deploy/discussions/new) about any aspect of this project.
+This is a rapidly evolving project. Please feel free to open an [issue](https://github.com/django-simple-deploy/django-simple-deploy/issues/new/choose) or a [discussion](https://github.com/django-simple-deploy/django-simple-deploy/discussions/new) about any aspect of this project.

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -27,17 +27,17 @@ Ways to contribute
 
 There are many ways to contribute. Choose the option that fits you best, and start contributing. :)
 
-- If you have a long-term interest in contributing, please introduce yourself on the [Introductions](https://github.com/ehmatthes/django-simple-deploy/discussions/130) thread.
+- If you have a long-term interest in contributing, please introduce yourself on the [Introductions](https://github.com/django-simple-deploy/django-simple-deploy/discussions/130) thread.
 - If you're newer to Django, or new to deployment, the simplest way to help is by [documenting a test run](test_run.md).
 - If you know a particular platform well, please share any thoughts you have about how to improve support for that platform:
     - You can make a [test run](test_run.md) on that platform and look at the configuration changes that `simple_deploy` makes for that platform.
     - Or, you can look in the `simple_deploy/management/commands/utils/` directory and find the `deploy_platform-name.py` file that targets the platform you know, and review the implementation details for configuration and deployment to that platform.
 - Respond to either of the two open discussions:
-    - [Open questions](https://github.com/ehmatthes/django-simple-deploy/discussions/132), a short list of questions related to reaching the stability needed for a 1.0 release.
-    - [Working towards idempotency](https://github.com/ehmatthes/django-simple-deploy/discussions/169), a focused question about making sure repeated `manage.py simple_deploy` calls will not cause issues in a project.
+    - [Open questions](https://github.com/django-simple-deploy/django-simple-deploy/discussions/132), a short list of questions related to reaching the stability needed for a 1.0 release.
+    - [Working towards idempotency](https://github.com/django-simple-deploy/django-simple-deploy/discussions/169), a focused question about making sure repeated `manage.py simple_deploy` calls will not cause issues in a project.
 - If you're ready to dig into the codebase, see the [Setting Up a Development Environment](development_environment.md) page.
 
 Code of Conduct
 ---
 
-`django-simple-deploy` operates under a clear [Code of Conduct](https://github.com/ehmatthes/django-simple-deploy/blob/main/old_docs/code_of_conduct.md).
+`django-simple-deploy` operates under a clear [Code of Conduct](https://github.com/django-simple-deploy/django-simple-deploy/blob/main/old_docs/code_of_conduct.md).

--- a/docs/contributing/parking_lot.md
+++ b/docs/contributing/parking_lot.md
@@ -11,32 +11,32 @@ This is a place to dump ideas that aren't yet actionable. This document exists t
 General ideas
 ---
 
-- Write a user-friendly deployment summary. See [#51](https://github.com/ehmatthes/django-simple-deploy/issues/51), and [#160](https://github.com/ehmatthes/django-simple-deploy/issues/160).
+- Write a user-friendly deployment summary. See [#51](https://github.com/django-simple-deploy/django-simple-deploy/issues/51), and [#160](https://github.com/django-simple-deploy/django-simple-deploy/issues/160).
 - Support one platform with an API-based workflow.
     - This will help clarify what kinds of utility functions should be included in core, for consistency of implementation, workflow, and testing.
-- Support nested project directory structure, ie projects created from `startproject <project-name>`, not `startproject <project-name> .` (with a dot). See [#55](https://github.com/ehmatthes/django-simple-deploy/issues/55).
-- Consider using Rich for nicer terminal output. See [#70](https://github.com/ehmatthes/django-simple-deploy/issues/70).
-- Implement a `--check` flag. This would inspect the system and project, and report any identifiable issues that would prevent deployment. It would not make any changes to the project. May do platform-specific validation as well? See [#80](https://github.com/ehmatthes/django-simple-deploy/issues/80).
-- Remove `old_docs/` directory. See [#138](https://github.com/ehmatthes/django-simple-deploy/issues/138).
-- Support deploying project from the Django Girls tutorial. See [#82](https://github.com/ehmatthes/django-simple-deploy/issues/82).
-- Support PDM. See [#137](https://github.com/ehmatthes/django-simple-deploy/issues/137).
-- Look at settings in [django-production](https://github.com/lincolnloop/django-production). See [#147](https://github.com/ehmatthes/django-simple-deploy/issues/147).
-- Set up CI. See [#148](https://github.com/ehmatthes/django-simple-deploy/issues/148).
-- Identify current branch? Warn about non-main branch? See [#150](https://github.com/ehmatthes/django-simple-deploy/issues/150).
-- Note talks, articles, discussion etc related to this project. See [#208](https://github.com/ehmatthes/django-simple-deploy/issues/208).
-- Consider a stability policy. See [#214](https://github.com/ehmatthes/django-simple-deploy/issues/214).
-- Consider a `--dry-run` feature. See [#247](https://github.com/ehmatthes/django-simple-deploy/issues/247).
-- Revisit `git status` check in simple_deploy.py. See [#261](https://github.com/ehmatthes/django-simple-deploy/issues/261).
-- Document use of development tools such as reset_project.py. See [#264](https://github.com/ehmatthes/django-simple-deploy/issues/264).
-- Look at consistency of platform messages. See [#270](https://github.com/ehmatthes/django-simple-deploy/issues/264).
-- Consider a tagline. [#284](https://github.com/ehmatthes/django-simple-deploy/issues/284).
-- Consider pyupgrade for finding old Python idioms that are no longer needed. See [#299](https://github.com/ehmatthes/django-simple-deploy/issues/299).
+- Support nested project directory structure, ie projects created from `startproject <project-name>`, not `startproject <project-name> .` (with a dot). See [#55](https://github.com/django-simple-deploy/django-simple-deploy/issues/55).
+- Consider using Rich for nicer terminal output. See [#70](https://github.com/django-simple-deploy/django-simple-deploy/issues/70).
+- Implement a `--check` flag. This would inspect the system and project, and report any identifiable issues that would prevent deployment. It would not make any changes to the project. May do platform-specific validation as well? See [#80](https://github.com/django-simple-deploy/django-simple-deploy/issues/80).
+- Remove `old_docs/` directory. See [#138](https://github.com/django-simple-deploy/django-simple-deploy/issues/138).
+- Support deploying project from the Django Girls tutorial. See [#82](https://github.com/django-simple-deploy/django-simple-deploy/issues/82).
+- Support PDM. See [#137](https://github.com/django-simple-deploy/django-simple-deploy/issues/137).
+- Look at settings in [django-production](https://github.com/lincolnloop/django-production). See [#147](https://github.com/django-simple-deploy/django-simple-deploy/issues/147).
+- Set up CI. See [#148](https://github.com/django-simple-deploy/django-simple-deploy/issues/148).
+- Identify current branch? Warn about non-main branch? See [#150](https://github.com/django-simple-deploy/django-simple-deploy/issues/150).
+- Note talks, articles, discussion etc related to this project. See [#208](https://github.com/django-simple-deploy/django-simple-deploy/issues/208).
+- Consider a stability policy. See [#214](https://github.com/django-simple-deploy/django-simple-deploy/issues/214).
+- Consider a `--dry-run` feature. See [#247](https://github.com/django-simple-deploy/django-simple-deploy/issues/247).
+- Revisit `git status` check in simple_deploy.py. See [#261](https://github.com/django-simple-deploy/django-simple-deploy/issues/261).
+- Document use of development tools such as reset_project.py. See [#264](https://github.com/django-simple-deploy/django-simple-deploy/issues/264).
+- Look at consistency of platform messages. See [#270](https://github.com/django-simple-deploy/django-simple-deploy/issues/264).
+- Consider a tagline. [#284](https://github.com/django-simple-deploy/django-simple-deploy/issues/284).
+- Consider pyupgrade for finding old Python idioms that are no longer needed. See [#299](https://github.com/django-simple-deploy/django-simple-deploy/issues/299).
 - Try simple_deploy with a micro framework such as [django-singlefile](https://github.com/andrewgodwin/django-singlefile) or [nanodjango](https://github.com/radiac/nanodjango).
 - Should the project support Poetry?
     - Poetry seems to be well-respected for developing libraries, but I don't know that anyone is really using it to manage dependencies for Django projects. If not, there's no reason to support it in this project.
     - Perhaps support it, but dial back some of the specificity of tests? Poetry is resolving at a finer grain size than we need to pay attention to?
     - I believe poetry does not conform to emerging standards for specifying Python dependencies. How much of a burden is it to support poetry? Perhaps moderate support, in the sense of exporting to requirements.txt?
-- There are some interesting notes in [#238](https://github.com/ehmatthes/django-simple-deploy/issues/238).
+- There are some interesting notes in [#238](https://github.com/django-simple-deploy/django-simple-deploy/issues/238).
 - Add `black` to CI.
 
 Testing
@@ -44,28 +44,28 @@ Testing
 
 - Check for each platform's CLI when needed before running tests that depend on it.
 - Check for poetry, and any other package manager, before running any tests that depend on it.
-- Allow tests to be run for one specific package manager. Or exclude a package manager? See [#270](https://github.com/ehmatthes/django-simple-deploy/issues/270).
-- Add a `--show-diff` argument to unit tests/ integration tests. See [#271](https://github.com/ehmatthes/django-simple-deploy/issues/271).
-- Consider using `uv` in place of `pip`, at least when testing. See [#291](https://github.com/ehmatthes/django-simple-deploy/issues/291).
-- Refine testing. See [#296](https://github.com/ehmatthes/django-simple-deploy/issues/296), and any open tasks in [#285](https://github.com/ehmatthes/django-simple-deploy/issues/285).
-- Move `build_dev_env.py` from `e2e_tests/utils/` to `developer_resources/`. See [#245](https://github.com/ehmatthes/django-simple-deploy/issues/245).
+- Allow tests to be run for one specific package manager. Or exclude a package manager? See [#270](https://github.com/django-simple-deploy/django-simple-deploy/issues/270).
+- Add a `--show-diff` argument to unit tests/ integration tests. See [#271](https://github.com/django-simple-deploy/django-simple-deploy/issues/271).
+- Consider using `uv` in place of `pip`, at least when testing. See [#291](https://github.com/django-simple-deploy/django-simple-deploy/issues/291).
+- Refine testing. See [#296](https://github.com/django-simple-deploy/django-simple-deploy/issues/296), and any open tasks in [#285](https://github.com/django-simple-deploy/django-simple-deploy/issues/285).
+- Move `build_dev_env.py` from `e2e_tests/utils/` to `developer_resources/`. See [#245](https://github.com/django-simple-deploy/django-simple-deploy/issues/245).
 
 Documentation
 ---
 
-- Add an `index.md` file for each main section. See [#139](https://github.com/ehmatthes/django-simple-deploy/issues/139).
-- Update docs to clarify how this project can be useful to platform hosts (companies). See [#144](https://github.com/ehmatthes/django-simple-deploy/issues/144).
+- Add an `index.md` file for each main section. See [#139](https://github.com/django-simple-deploy/django-simple-deploy/issues/139).
+- Update docs to clarify how this project can be useful to platform hosts (companies). See [#144](https://github.com/django-simple-deploy/django-simple-deploy/issues/144).
 
 New platforms
 ---
 
-- Support Railway. See [#75](https://github.com/ehmatthes/django-simple-deploy/issues/75).
+- Support Railway. See [#75](https://github.com/django-simple-deploy/django-simple-deploy/issues/75).
 
 
 Fly.io
 ---
 
-- Simplify approach to checking for db. See [#297](https://github.com/ehmatthes/django-simple-deploy/issues/297).
+- Simplify approach to checking for db. See [#297](https://github.com/django-simple-deploy/django-simple-deploy/issues/297).
 
 Platform.sh
 ---
@@ -77,8 +77,8 @@ Platform.sh
 Heroku
 ---
 
-- If not pushing from the main branch, state that explicitly. Consider confirming that's what user wants. State the branch name explicitly in the summary message. See [#5](https://github.com/ehmatthes/django-simple-deploy/issues/5).
-- Reconsider Heroku support. People have lost confidence in Heroku in recent years, but it still keeps largely working. See [#91](https://github.com/ehmatthes/django-simple-deploy/issues/91).
+- If not pushing from the main branch, state that explicitly. Consider confirming that's what user wants. State the branch name explicitly in the summary message. See [#5](https://github.com/django-simple-deploy/django-simple-deploy/issues/5).
+- Reconsider Heroku support. People have lost confidence in Heroku in recent years, but it still keeps largely working. See [#91](https://github.com/django-simple-deploy/django-simple-deploy/issues/91).
 
 
 Windows
@@ -87,7 +87,7 @@ Windows
 - Cloning to a Windows VM automatically started a development server for the sample project?!
 
 ```cmd
-C:\Users\eric>git clone https://github.com/ehmatthes/django-simple-deploy.git
+C:\Users\eric>git clone https://github.com/django-simple-deploy/django-simple-deploy.git
 Cloning into 'django-simple-deploy'...
 remote: Enumerating objects: 4832, done.
 remote: Counting objects: 100% (1000/1000), done.

--- a/docs/contributing/test_run.md
+++ b/docs/contributing/test_run.md
@@ -28,7 +28,7 @@ For a test run, feel free to try `simple_deploy` against the provided sample pro
 
 Here are the overall steps you'll take:
 
-- Open an issue using the [Documenting a Test Run](https://github.com/ehmatthes/django-simple-deploy/issues/new?assignees=&labels=&template=documenting-a-test-run.md&title=Documenting+a+Test+Run) issue template.
+- Open an issue using the [Documenting a Test Run](https://github.com/django-simple-deploy/django-simple-deploy/issues/new?assignees=&labels=&template=documenting-a-test-run.md&title=Documenting+a+Test+Run) issue template.
 - Fill in the initial information in the template.
 - Clone the sample repository, if you're not testing against your own project.
 - Run `simple_deploy` in either configuration mode, or the automated mode.
@@ -120,6 +120,6 @@ If you have any final thoughts about how `django-simple-deploy` works, please sh
 
 Feel free to do as many test runs as you want. For example you might want to deploy to a different platform, or try a different dependency management system, or deploy a different project.
 
-This is also a great time to try running the [integration tests](https://github.com/ehmatthes/django-simple-deploy/blob/main/old_docs/integration_tests.md) for the platform you just targeted. Integration tests automate everything you just did. (Documentation for integration tests has not been migrated here yet.)
+This is also a great time to try running the [integration](../testing/integration_tests.md) and [end-to-end](../testing/e2e_tests.md) tests for the platform you just targeted. End-to-end tests automate everything you just did.
 
 If you want to contribute in other ways, see the main [Contributing](index.md) page for a variety of ways to help out.

--- a/docs/general_documentation/choosing_platform.md
+++ b/docs/general_documentation/choosing_platform.md
@@ -12,7 +12,7 @@ Choosing a platform for your first deployment might seem difficult, because ther
 
 This page summarizes the major strengths and potential drawbacks of each platform.
 
-*Note: Best efforts are made to keep this page up to date. If you see something that is no longer accurate, please [open an issue](https://github.com/ehmatthes/django-simple-deploy/issues) and include a link to the updated information.*
+*Note: Best efforts are made to keep this page up to date. If you see something that is no longer accurate, please [open an issue](https://github.com/django-simple-deploy/django-simple-deploy/issues) and include a link to the updated information.*
 
 ## Quick comparison
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@ hide:
 
 # django-simple-deploy
 
-`django-simple-deploy` configures your Django project for deployment to a number of different platforms. For some platforms, it can automate the entire deployment process. Currently, three platforms have preliminary support: [Fly.io](https://fly.io), [Platform.sh](https://platform.sh), and [Heroku](https://heroku.com).
+`django-simple-deploy` configures your Django project for deployment to a number of different platforms. For some platforms, it can automate the entire deployment process. The project currently supports three platforms: [Fly.io](https://fly.io), [Platform.sh](https://platform.sh), and [Heroku](https://heroku.com).
 
 Here's what automated deployment on [Fly.io](https://fly.io) looks like:
 
@@ -31,5 +31,3 @@ For help deploying to a specific platform, start here:
 - If you're not sure which platform to choose, here's an [overview](general_documentation/choosing_platform.md) of the different platforms.
 - If you're interested in the motivations for `django-simple-deploy`, start with the [Rationale](design_docs/rationale.md).
 - If you're interested in helping out, see the [Contributing](contributing/index.md) page.
-
-Note: The original documentation for this project was in the [GitHub repo](https://github.com/ehmatthes/django-simple-deploy/tree/main/old_docs), and some parts of the documentation have not been moved here yet.

--- a/docs/maintaining/adr.md
+++ b/docs/maintaining/adr.md
@@ -74,4 +74,4 @@ Outcomes:
 
 Extra info:
 
-- Related issue: [#168](https://github.com/ehmatthes/django-simple-deploy/issues/168)
+- Related issue: [#168](https://github.com/django-simple-deploy/django-simple-deploy/issues/168)

--- a/docs/quick_starts/quick_start_flyio.md
+++ b/docs/quick_starts/quick_start_flyio.md
@@ -84,6 +84,6 @@ $ fly ssh console
 
 ## Troubleshooting
 
-If deployment doesn't work, feel free to open an [issue](https://github.com/ehmatthes/django-simple-deploy/issues). Please share the OS you're  using locally, and the specific error message or unexpected behavior you saw. If the project you're deploying is hosted in a public repository, please share that as well.
+If deployment doesn't work, feel free to open an [issue](https://github.com/django-simple-deploy/django-simple-deploy/issues). Please share the OS you're  using locally, and the specific error message or unexpected behavior you saw. If the project you're deploying is hosted in a public repository, please share that as well.
 
 Please remember that `django-simple-deploy` is in a preliminary state. That said, I'd love to know the specific issues people are running into so we can reach a 1.0 state in a reasonable time frame.

--- a/docs/quick_starts/quick_start_heroku.md
+++ b/docs/quick_starts/quick_start_heroku.md
@@ -79,6 +79,6 @@ $ git push heroku main
 
 ## Troubleshooting
 
-If deployment does not work, please feel free to open an [issue](https://github.com/ehmatthes/django-simple-deploy/issues). Please share the OS you're  using locally, and the specific error message or unexpected behavior you saw. If the project you're deploying is hosted in a public repository, please share that as well.
+If deployment does not work, please feel free to open an [issue](https://github.com/django-simple-deploy/django-simple-deploy/issues). Please share the OS you're  using locally, and the specific error message or unexpected behavior you saw. If the project you're deploying is hosted in a public repository, please share that as well.
 
 Please remember that `django-simple-deploy` is in a preliminary state. That said, I'd love to know the specific issues people are running into so we can reach a 1.0 state in a reasonable time frame.

--- a/docs/quick_starts/quick_start_platformsh.md
+++ b/docs/quick_starts/quick_start_platformsh.md
@@ -73,6 +73,6 @@ $ platform push
 
 ## Troubleshooting
 
-If deployment doesn't work, please feel free to open an [issue](https://github.com/ehmatthes/django-simple-deploy/issues). Please share the OS you're  using locally, and the specific error message or unexpected behavior you saw. If the project you're deploying is hosted in a public repository, please share that as well.
+If deployment doesn't work, please feel free to open an [issue](https://github.com/django-simple-deploy/django-simple-deploy/issues). Please share the OS you're  using locally, and the specific error message or unexpected behavior you saw. If the project you're deploying is hosted in a public repository, please share that as well.
 
 Please remember that `django-simple-deploy` is in a preliminary state. That said, I'd love to know the specific issues people are running into so we can reach a 1.0 state in a reasonable time frame.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: django-simple-deploy
 
-repo_url: https://github.com/ehmatthes/django-simple-deploy/
+repo_url: https://github.com/django-simple-deploy/django-simple-deploy/
 
 markdown_extensions:
   - attr_list

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,8 +6,8 @@ long_description = file: README.md
 long_description_content_type=text/markdown
 project_urls =
     Documentation = https://django-simple-deploy.readthedocs.io/en/latest/
-    GitHub = https://github.com/ehmatthes/django-simple-deploy
-    Changelog = https://github.com/ehmatthes/django-simple-deploy/blob/main/CHANGELOG.md
+    GitHub = https://github.com/django-simple-deploy/django-simple-deploy
+    Changelog = https://github.com/django-simple-deploy/django-simple-deploy/blob/main/CHANGELOG.md
 
 author = Eric Matthes
 author_email = ehmatthes@gmail.com


### PR DESCRIPTION
Docs were pointing to the dsd repo in my personal GH account. Update all links to point to the repo's new location in this org.