### PR TITLE
Specify dsd version

### DIFF
--- a/django_simple_deploy/management/commands/deploy.py
+++ b/django_simple_deploy/management/commands/deploy.py
@@ -29,6 +29,7 @@ import sys, os, platform, re, subprocess, logging, shlex
 from datetime import datetime
 from pathlib import Path
 from importlib import import_module
+from importlib.metadata import version
 
 from django.core.management.base import BaseCommand
 from django.conf import settings
@@ -119,6 +120,9 @@ class Command(BaseCommand):
             self._log_cli_args(options)
 
         self._validate_command()
+
+        # Get installed version.
+        dsd_config.version = version("django-simple-deploy")
 
         # Import the platform-specific plugin module. This performs some validation, so
         # it's best to call this before modifying project in any way.

--- a/django_simple_deploy/management/commands/deploy.py
+++ b/django_simple_deploy/management/commands/deploy.py
@@ -498,7 +498,8 @@ class Command(BaseCommand):
         """
         msg = "\nLooking for django-simple-deploy in requirements..."
         plugin_utils.write_output(msg)
-        plugin_utils.add_package("django-simple-deploy")
+        version_string = f"=={dsd_config.version}"
+        plugin_utils.add_package("django-simple-deploy", version=version_string)
 
     def _validate_plugin(self, pm):
         """Check that all required hooks are implemeted by plugin.

--- a/django_simple_deploy/management/commands/utils/dsd_config.py
+++ b/django_simple_deploy/management/commands/utils/dsd_config.py
@@ -19,6 +19,9 @@ class DSDConfig:
 
     def __init__(self):
         """Define all attributes that will need to be shared."""
+        # Version of the currently installed version of django-simple-deploy.
+        self.version = None
+
         # Aspects of user's system.
         self.on_windows = None
         self.on_macos = None
@@ -51,6 +54,10 @@ class DSDConfig:
 
     def validate(self):
         """Make sure all required attributes have been defined."""
+        if not self.version:
+            msg = "Could not identify version of django-simple-deploy in use."
+            raise DSDCommandError(msg)
+
         if not self.pkg_manager:
             msg = "Could not identify dependency management system in use."
             raise DSDCommandError(msg)

--- a/tests/e2e_tests/utils/build_dev_env.py
+++ b/tests/e2e_tests/utils/build_dev_env.py
@@ -208,8 +208,8 @@ make_sp_call("git tag -am '' 'INITIAL_STATE'")
 add_dsd(project_dir)
 
 # Make sure we have a clean status before calling the deploy command.
-make_sp_call("git commit -am 'Added simple_deploy to INSTALLED_APPS.'")
-make_sp_call("git tag -am '' 'ADDED_SD'")
+make_sp_call("git commit -am 'Added django_simple_deploy to INSTALLED_APPS.'")
+make_sp_call("git tag -am '' 'ADDED_DSD'")
 
 # Repeat the project directory, so user can go there easily.
 print("\n\n --- Finished setup ---")

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -3,6 +3,7 @@
 import subprocess, re, sys, os, tempfile
 from pathlib import Path
 from time import sleep
+from importlib.metadata import version
 
 import pytest
 
@@ -168,3 +169,18 @@ def pkg_manager(request):
     - String representing package manager: req_txt | poetry | pipenv
     """
     return request.node.callspec.params.get("reset_test_project")
+
+@pytest.fixture(scope="session")
+def dsd_version():
+    """Get the version of django-simple-deploy that's being tested.
+
+    This is used to dynamically generate reference files which include a reference
+    to the current version. For example the `deploy` command adds a requirement like this:
+    django-simple-deploy==0.9.3
+
+    A static reference file doesn't work.
+
+    Returns:
+        Str: version of django-simple-deploy that's being tested.
+    """
+    return version("django-simple-deploy")

--- a/tests/integration_tests/utils/it_helper_functions.py
+++ b/tests/integration_tests/utils/it_helper_functions.py
@@ -85,7 +85,6 @@ def check_reference_file(
     if context:
         contents = fp_reference.read_text()
         for placeholder, replacement in context.items():
-            # contents = contents.replace("{" + placeholder + "}", replacement)
             contents = contents.replace(f"{{{placeholder}}}", replacement)
 
         fp_reference = tmp_path / filename

--- a/tests/integration_tests/utils/it_helper_functions.py
+++ b/tests/integration_tests/utils/it_helper_functions.py
@@ -21,13 +21,14 @@ from django_simple_deploy.management.commands.utils.command_errors import (
 )
 
 
-def check_reference_file(tmp_proj_dir, filepath, plugin_name="", reference_filename=""):
+def check_reference_file(tmp_proj_dir, filepath, plugin_name="", reference_filename="", reference_filepath=None):
     """Check that the test version of the file matches the reference version
     of the file.
 
     - filepath: relative path from tmp_proj_dir to test file
     - reference_filename: the name of the  reference file, if it has a
       different name than the generated file
+    - reference_filepath: absolute path to reference file
     - plugin_name: used to find the path to reference files.
 
     Asserts:
@@ -56,7 +57,9 @@ def check_reference_file(tmp_proj_dir, filepath, plugin_name="", reference_filen
 
     # Only plugins use reference files for now. Assume plugin dir is in same directory as
     # django-simple-deploy.
-    if plugin_name:
+    if reference_filepath:
+        fp_reference = reference_filepath
+    elif plugin_name:
         plugin_root_dir = sd_root_dir.parent / plugin_name
         assert plugin_root_dir.exists()
 

--- a/tests/integration_tests/utils/it_helper_functions.py
+++ b/tests/integration_tests/utils/it_helper_functions.py
@@ -21,7 +21,15 @@ from django_simple_deploy.management.commands.utils.command_errors import (
 )
 
 
-def check_reference_file(tmp_proj_dir, filepath, plugin_name="", reference_filename="", reference_filepath=None, context=None, tmp_path=None):
+def check_reference_file(
+    tmp_proj_dir,
+    filepath,
+    plugin_name="",
+    reference_filename="",
+    reference_filepath=None,
+    context=None,
+    tmp_path=None,
+):
     """Check that the test version of the file matches the reference version
     of the file.
 
@@ -81,9 +89,7 @@ def check_reference_file(tmp_proj_dir, filepath, plugin_name="", reference_filen
             contents = contents.replace(f"{{{placeholder}}}", replacement)
 
         fp_reference = tmp_path / filename
-        breakpoint()
         fp_reference.write_text(contents)
-
 
     # The test file and reference file will always have different modified
     #   timestamps, so no need to use default shallow=True.


### PR DESCRIPTION
When adding django-simple-deploy as a dependency of the project, specifies the currently-installed version of django-simple-deploy. This is really helpful in testing especially around brand-new releases where a platform's cache may cause the most recent version to keep being installed without a clear specification of the newest release.