### PR TITLE
GitHub Actions: Detecting the operating system with $runner.os

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Run macOS and Linux tests
 
-        if: startsWith(matrix.os, 'macos-') || startsWith(matrix.os, 'ubuntu-')
+        if: runner.os == 'Linux' || runner.os == 'macOS'
         run: |
           # Install uv
           curl -LsSf https://astral.sh/uv/install.sh | sh
@@ -63,7 +63,7 @@ jobs:
 
       - name: Run Windows tests
 
-        if: startsWith(matrix.os, 'windows-')
+        if: runner.os == 'Windows'
         run: |
           # Install uv
           powershell -c "irm https://astral.sh/uv/install.ps1 | iex"


### PR DESCRIPTION
Easier to read and recommended by GitHub.  https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#detecting-the-operating-system