### PR TITLE
Update "Choosing a Platform" page.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ For inspiration and motivation, see [Keep a CHANGELOG](https://keepachangelog.co
 
 This release will have a stable public interface for end users, and for plugin developers as well. The project will continue to be refined internally and may gain some new features, but will have overall stability as a high priority.
 
+### (Unreleased)
+
+#### External changes
+
+- Update information about all three platforms on the [Choosing a Platform](https://django-simple-deploy.readthedocs.io/en/latest/general_documentation/choosing_platform/) page.
+
 ### 1.1.0
 
 #### External changes

--- a/docs/general_documentation/choosing_platform.md
+++ b/docs/general_documentation/choosing_platform.md
@@ -20,12 +20,11 @@ This page summarizes the strengths and potential drawbacks of each platform.
 | --------------------- | ------------------ | ----------------------- | ----------------------------------------------------------- |
 | Credit Cards required for trial | N/A                | N/A                      | N/A |
 | Free trial length     | No free trial | No free trial ^1^ | No free trial |
-| Cheapest paid plan    | $1.94/mo              | $12/mo                  | $10/mo ^2^ ($5 [Eco dyno](https://www.heroku.com/pricing/) + $5 [Essential 0 Postgres](https://elements.heroku.com/addons/heroku-postgresql))                     |
+| Cheapest paid plan    | $1.94/mo              | $12/mo                  | $10/mo ^2^                     |
 | Company founded       | 2017               | 2012                    | 2007                                                        |
 
-1: The new PAAS service [UpSun](https://upsun.com) from Platform.sh offers a free trial, but django-simple-deploy does not support deployment to UpSun at this point.
-
-2: This uses a $5/month [Eco dyno](https://www.heroku.com/pricing/) and a $5/month [Essential 0 Postgres](https://elements.heroku.com/addons/heroku-postgresql) database.
+1. The new PAAS service [UpSun](https://upsun.com) from Platform.sh offers a free trial, but django-simple-deploy does not support deployment to UpSun at this point.
+2. Using a $5/month [Eco dyno](https://www.heroku.com/pricing/) and a $5/month [Essential 0 Postgres](https://elements.heroku.com/addons/heroku-postgresql) database.
 
 ## Detailed notes
 
@@ -98,7 +97,7 @@ This page summarizes the strengths and potential drawbacks of each platform.
 
     **Issues**
 
-    * Heroku was a great platform in the late 2000s through the mid 2010s, but then it began to stagnate. Packages that were recommended for deployment were archived and unmaintained, even though they were officially still recommended. Heroku "just worked" for a long time, but recently that neglect has caught up to them. They are in the midst of restructuring their platform, and people are reasonably concerned about Heroku's long-term stability.
+    * Heroku was a great platform in the late 2000s through the mid 2010s, but then it began to stagnate. Packages that were recommended for deployment were archived and unmaintained, even though they were officially still recommended. Heroku "just worked" for a long time, but recently that neglect has caught up to them. They've been restructuring their platform for a long time now, and people are reasonably concerned about Heroku's long-term stability.
     * Heroku has had major incidents and outages in recent years, which they took a long time to resolve and communicated poorly about. This is the more significant reason many people have moved away from them in recent years.
     * Heroku was famous for a very generous free tier, where you could deploy up to 5 apps at a time including a small Heroku Postgres database. This kind of offering sounds nice, but it also draws abuse. Heroku was constantly fighting things like auto-deployed crypto miners. They no longer offer a free tier. Their cheapest plans are still reasonably priced, though, so the end of the free tier should not rule them out as a hosting option.
 
@@ -106,13 +105,12 @@ This page summarizes the strengths and potential drawbacks of each platform.
 
     * [Heroku home page](https://www.heroku.com)
     * [Pricing](https://www.heroku.com/pricing)
-        * *Note: Heroku's lowest-priced tiers were recently [restructured](https://blog.heroku.com/new-low-cost-plans).*
     * [Docs home page](https://devcenter.heroku.com)
     * [CLI installation](https://devcenter.heroku.com/articles/heroku-cli)
     * [CLI reference](https://devcenter.heroku.com/categories/command-line)
     * [Python on Heroku](https://devcenter.heroku.com/categories/python-support)
     * [Getting Started on Heroku with Python](https://devcenter.heroku.com/articles/getting-started-with-python?singlepage=true)
-    * [Deploying Python and Django Apps on Heroku](https://devcenter.heroku.com/articles/deploying-python)
+    * [Working with Django (on Heroku)](https://devcenter.heroku.com/categories/working-with-django)
 
     **Using `django-simple-deploy` with Heroku**
 

--- a/docs/general_documentation/choosing_platform.md
+++ b/docs/general_documentation/choosing_platform.md
@@ -18,10 +18,12 @@ This page summarizes the strengths and potential drawbacks of each platform.
 
 |                       | Fly.io             | Platform.sh             | Heroku                                                      |
 | --------------------- | ------------------ | ----------------------- | ----------------------------------------------------------- |
-| Credit Cards required for trial | N/A                | No                      | N/A |
-| Free trial length     | No free trial | 30 days | No free trial |
-| Cheapest paid plan    | $1.94/mo              | $10/mo                  | [$10/mo](https://blog.heroku.com/new-low-cost-plans) ($5 Eco dyno + $5 Mini Postgres)                     |
+| Credit Cards required for trial | N/A                | N/A                      | N/A |
+| Free trial length     | No free trial | No free trial ^1^ | No free trial |
+| Cheapest paid plan    | $1.94/mo              | $12/mo                  | [$10/mo](https://blog.heroku.com/new-low-cost-plans) ($5 Eco dyno + $5 Mini Postgres)                     |
 | Company founded       | 2017               | 2012                    | 2007                                                        |
+
+1: The new PAAS service [UpSun](https://upsun.com) from Platform.sh offers a free trial, but django-simple-deploy does not support deployment to UpSun at this point.
 
 ## Detailed notes
 
@@ -62,14 +64,13 @@ This page summarizes the strengths and potential drawbacks of each platform.
 
     **Strengths**
 
-    * Platform.sh does not require a credit card for its free trial.
     * Once you have an environment set up with the Platform.sh tools, pushing a project and maintaining it is as straightforward as it is on any other comparable platform.
 
 
     **Issues**
 
     * Error messages about resource usage are unclear. For example, new users are limited to two new apps per day until they have been billed successfully three times. Since billing occurs once a month, this limit applies for several months, even though you're willing to pay for usage. Also, if you try to create a new project and it fails because of this issue, you don't get a specific error message. You have to contact support to find out if this is the reason for failure, or if something else went wrong.
-    * The CLI requires PHP for installation, and requires a bash shell for deployment. This isn't particularly difficult on macOS or Linux, but installation is not straightforward on Windows if you don't already have Windows Subsystem for Linux (WSL) installed, or a comparable bash-compatible environment.
+    * The CLI requires a bash shell for deployment. This isn't particularly difficult on macOS or Linux, but installation is not straightforward on Windows if you don't already have Windows Subsystem for Linux (WSL) installed, or a comparable bash-compatible environment.
 
     **Links**
 

--- a/docs/general_documentation/choosing_platform.md
+++ b/docs/general_documentation/choosing_platform.md
@@ -6,20 +6,20 @@ hide:
 
 # Choosing a Platform
 
-Choosing a platform for your first deployment might seem difficult, because there are many options to choose from these days. It's hard to say that any one platform is better than any other, because they all take different approaches to a complex problem - pushing your project to a remote server in a way that lets it run reliably, at a reasonable cost.
+Choosing a platform to deploy to might seem difficult, because there are many to choose from these days. It's hard to say that any one platform is better than any other, because they all take different approaches to a complex problem - pushing your project to a remote server in a way that lets it run reliably, at a reasonable cost.
 
-`django-simple-deploy` aims to make it easier to choose a platform by simplifying your first deployments to a new platform. You don't have to do a deep dive into each platform's documentation in order to get a deployment up and running. Typically, you can make an account with the platform you're interested in, install that platform's CLI, install the deployment plugin for that platform, and then push your project. You get a working deployment with very little effort, which makes further exploration of each platform much easier and much less frustrating.
+`django-simple-deploy` aims to make it easier to choose a platform by simplifying your first deployments to a variety of hosts. You don't have to do a deep dive into each platform's documentation in order to get a deployment up and running. Typically, you can make an account with the platform you're interested in, install that platform's CLI, install the plugin for that platform, and then push your project. You get a working deployment with very little effort, which makes further exploration of each platform much easier and much less frustrating.
 
-This page summarizes the major strengths and potential drawbacks of each platform.
+This page summarizes the strengths and potential drawbacks of each platform.
 
-*Note: Best efforts are made to keep this page up to date. If you see something that is no longer accurate, please [open an issue](https://github.com/django-simple-deploy/django-simple-deploy/issues) and include a link to the updated information.*
+*Note: Best efforts are made to keep this page up to date. If you see something that's no longer accurate, please [open an issue](https://github.com/django-simple-deploy/django-simple-deploy/issues) and include a link to the updated information.*
 
 ## Quick comparison
 
 |                       | Fly.io             | Platform.sh             | Heroku                                                      |
 | --------------------- | ------------------ | ----------------------- | ----------------------------------------------------------- |
-| Credit Cards required for trial | Yes                | No                      | Yes |
-| Free trial length     | Unlimited time | 30 days | No free trial |
+| Credit Cards required for trial | N/A                | No                      | N/A |
+| Free trial length     | No free trial | 30 days | No free trial |
 | Cheapest paid plan    | $1.94/mo              | $10/mo                  | [$10/mo](https://blog.heroku.com/new-low-cost-plans) ($5 Eco dyno + $5 Mini Postgres)                     |
 | Company founded       | 2017               | 2012                    | 2007                                                        |
 
@@ -33,19 +33,19 @@ This page summarizes the major strengths and potential drawbacks of each platfor
 
     **Strengths**
 
-    * Fly.io does not require a credit card for its free trial, and the free trial does not have a time limit.
-    * Even after you enter a credit card, the free offering is enough to keep a small app running.
     * Offers a [public forum](https://community.fly.io) for support, and allows you to search for issues (and resolutions) that others have had.
-    * Fly.io seems to be well regarded in the post-Heroku era.
+    * The cheapest plan is currently about $2/month, but that machine only has 256MB of RAM. A 1GB is currently less than $6/month.
+    * The documentation [states](https://fly.io/docs/about/billing/#if-you-dont-have-a-credit-card) that you can use a prepaid card to buy credits. The minimum purchase of credits is $25.
 
     **Issues**
 
-    * I am not aware of any specific issues with Fly.io at the moment, but the distributed server model may not be suitable for all projects.
+    * The distributed server model may not be suitable for all projects.
+    * Fly has been growing for a while, and has had some outages along the way that have frustrated some users.
 
     **Links**
 
     * [Fly.io home page](https://fly.io/)
-    * [Pricing](https://fly.io/docs/about/pricing/)
+    * [Pricing](https://fly.io/docs/about/pricing/) | [Pricing calculator](https://fly.io/calculator)
     * [Docs home page](https://fly.io/docs/)
     * [CLI installation](https://fly.io/docs/hands-on/install-flyctl/)
     * [CLI reference](https://fly.io/docs/flyctl/)

--- a/docs/general_documentation/choosing_platform.md
+++ b/docs/general_documentation/choosing_platform.md
@@ -20,10 +20,12 @@ This page summarizes the strengths and potential drawbacks of each platform.
 | --------------------- | ------------------ | ----------------------- | ----------------------------------------------------------- |
 | Credit Cards required for trial | N/A                | N/A                      | N/A |
 | Free trial length     | No free trial | No free trial ^1^ | No free trial |
-| Cheapest paid plan    | $1.94/mo              | $12/mo                  | [$10/mo](https://blog.heroku.com/new-low-cost-plans) ($5 Eco dyno + $5 Mini Postgres)                     |
+| Cheapest paid plan    | $1.94/mo              | $12/mo                  | $10/mo ^2^ ($5 [Eco dyno](https://www.heroku.com/pricing/) + $5 [Essential 0 Postgres](https://elements.heroku.com/addons/heroku-postgresql))                     |
 | Company founded       | 2017               | 2012                    | 2007                                                        |
 
 1: The new PAAS service [UpSun](https://upsun.com) from Platform.sh offers a free trial, but django-simple-deploy does not support deployment to UpSun at this point.
+
+2: This uses a $5/month [Eco dyno](https://www.heroku.com/pricing/) and a $5/month [Essential 0 Postgres](https://elements.heroku.com/addons/heroku-postgresql) database.
 
 ## Detailed notes
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,6 +4,9 @@ repo_url: https://github.com/django-simple-deploy/django-simple-deploy/
 
 markdown_extensions:
   - attr_list
+  - pymdownx.caret
+  - pymdownx.mark
+  - pymdownx.tilde
   - pymdownx.emoji:
       emoji_index: !!python/name:materialx.emoji.twemoji
       emoji_generator: !!python/name:materialx.emoji.to_svg


### PR DESCRIPTION
Update [Choosing a Platform](https://django-simple-deploy.readthedocs.io/en/latest/general_documentation/choosing_platform/) page, with current info for all three platforms shown.