### PR TITLE
Avoid writing to console if logging streams to console

### DIFF
--- a/django_simple_deploy/management/commands/utils/plugin_utils.py
+++ b/django_simple_deploy/management/commands/utils/plugin_utils.py
@@ -540,21 +540,20 @@ def add_req_txt_pkg(req_txt_path, package, version):
     req_txt_path.write_text(contents + pkg_string)
 
 def logs_to_console(logger=None):
-    """Check if logging is configured to stream to stdout or stderr.
-
-    If so, we'll avoid writing to console, because users will see doubled output.
-    """
+    """Check if logging is configured to stream to stdout or stderr."""
     if not logger:
         logger = logging.getLogger(__name__)
 
     for handler in logger.handlers:
-        is_handler = isinstance(handler, logging.StreamHandler)
-        streams_stdout = getattr(handler, "stream", None) is sys.stdout
-        streams_stderr = getattr(handler, "stream", None) is sys.stderr
+        if not isinstance(handler, logging.StreamHandler):
+            continue
 
-        if is_handler and (streams_stdout or streams_stderr):
+        if handler.stream in (sys.stdout, sys.stderr):
             return True
 
     if logger.propagate and logger.parent:
         return logs_to_console(logger.parent)
+
+    # Logging is not configured to stream to stdout or stderr.
     return False
+    

--- a/django_simple_deploy/management/commands/utils/plugin_utils.py
+++ b/django_simple_deploy/management/commands/utils/plugin_utils.py
@@ -312,7 +312,7 @@ def write_output(output, write_to_console=True, skip_logging=False):
     """
     output_str = get_string_from_output(output)
 
-    if write_to_console:
+    if write_to_console and not logs_to_console():
         dsd_config.stdout.write(output_str)
 
     if not skip_logging:
@@ -537,3 +537,31 @@ def add_req_txt_pkg(req_txt_path, package, version):
     contents = req_txt_path.read_text()
     pkg_string = f"\n{package + version}"
     req_txt_path.write_text(contents + pkg_string)
+
+def logs_to_console(logger=None):
+    """Check if logging is configured to stream to stdout."""
+    import sys
+
+    # breakpoint()
+    # logger = logging.getLogger()
+    # log_handler = logger.handlers[0]
+    # breakpoint()
+
+    # if isinstance(log_handler, logging.StreamHandler) and getattr(log_handler, "stream", None) is sys.stdout:
+    #     return True
+
+    # if logger.propagate and logger.parent:
+    #     return logging_streams_to_stdout(logger.parent)
+
+    # # Logger does not write to stdout.
+    # return False
+    if not logger:
+        logger = logging.getLogger(__name__)
+    for handler in logger.handlers:
+        # breakpoint()
+        # if isinstance(handler, logging.StreamHandler) and getattr(handler, "stream", None) is sys.stdout:
+        if isinstance(handler, logging.StreamHandler) and handler.stream.name in ("<stdout>", "<stderr>"):
+            return True
+    if logger.propagate and logger.parent:
+        return logs_to_console(logger.parent)
+    return False

--- a/django_simple_deploy/management/commands/utils/plugin_utils.py
+++ b/django_simple_deploy/management/commands/utils/plugin_utils.py
@@ -7,6 +7,7 @@ import logging
 import re
 import subprocess
 import shlex
+import sys
 import toml
 from pathlib import Path
 
@@ -539,30 +540,21 @@ def add_req_txt_pkg(req_txt_path, package, version):
     req_txt_path.write_text(contents + pkg_string)
 
 def logs_to_console(logger=None):
-    """Check if logging is configured to stream to stdout."""
-    import sys
+    """Check if logging is configured to stream to stdout or stderr.
 
-    # breakpoint()
-    # logger = logging.getLogger()
-    # log_handler = logger.handlers[0]
-    # breakpoint()
-
-    # if isinstance(log_handler, logging.StreamHandler) and getattr(log_handler, "stream", None) is sys.stdout:
-    #     return True
-
-    # if logger.propagate and logger.parent:
-    #     return logging_streams_to_stdout(logger.parent)
-
-    # # Logger does not write to stdout.
-    # return False
+    If so, we'll avoid writing to console, because users will see doubled output.
+    """
     if not logger:
         logger = logging.getLogger(__name__)
+
     for handler in logger.handlers:
-        # breakpoint()
-        # if isinstance(handler, logging.StreamHandler) and getattr(handler, "stream", None) is sys.stdout:
-        # if isinstance(handler, logging.StreamHandler) and handler.stream.name in ("<stdout>", "<stderr>"):
-        if isinstance(handler, logging.StreamHandler) and (handler.stream is sys.stderr or handler.stream is sys.stdout):
+        is_handler = isinstance(handler, logging.StreamHandler)
+        streams_stdout = getattr(handler, "stream", None) is sys.stdout
+        streams_stderr = getattr(handler, "stream", None) is sys.stderr
+
+        if is_handler and (streams_stdout or streams_stderr):
             return True
+
     if logger.propagate and logger.parent:
         return logs_to_console(logger.parent)
     return False

--- a/django_simple_deploy/management/commands/utils/plugin_utils.py
+++ b/django_simple_deploy/management/commands/utils/plugin_utils.py
@@ -560,7 +560,8 @@ def logs_to_console(logger=None):
     for handler in logger.handlers:
         # breakpoint()
         # if isinstance(handler, logging.StreamHandler) and getattr(handler, "stream", None) is sys.stdout:
-        if isinstance(handler, logging.StreamHandler) and handler.stream.name in ("<stdout>", "<stderr>"):
+        # if isinstance(handler, logging.StreamHandler) and handler.stream.name in ("<stdout>", "<stderr>"):
+        if isinstance(handler, logging.StreamHandler) and (handler.stream is sys.stderr or handler.stream is sys.stdout):
             return True
     if logger.propagate and logger.parent:
         return logs_to_console(logger.parent)

--- a/tests/integration_tests/platform_agnostic_tests/test_console_output.py
+++ b/tests/integration_tests/platform_agnostic_tests/test_console_output.py
@@ -1,0 +1,54 @@
+"""Check that console output is what we expect it to be.
+
+Should be able to use any valid platform for these calls.
+
+This test was motivated by seeing every line of output doubled for an end
+user who had logging configured to stream to stdout.
+"""
+
+from pathlib import Path
+import subprocess, shlex, os, sys
+
+import pytest
+
+from ..utils import manage_sample_project as msp
+
+
+# --- Helper functions ---
+
+
+def execute_quick_command(tmp_project, cmd):
+    """Run a quick command, and return CompletedProcess object."""
+    cmd_parts = shlex.split(cmd)
+    os.chdir(tmp_project)
+    return subprocess.run(cmd_parts, capture_output=True)
+
+
+# --- Test functions ---
+
+def test_standard_output(tmp_project):
+    """Test that output in a standard `deploy` call is correct.
+    """
+    # For now, this test only works if the dsd-flyio plugin is being tested.
+    # Skip if that's not available.
+    import importlib.util
+
+    if not importlib.util.find_spec("dsd_flyio"):
+        pytest.skip("The plugin dsd-flyio needs to be installed to run this test.")
+
+    dsd_command = "python manage.py deploy"
+    stdout, stderr = msp.call_deploy(tmp_project, dsd_command)
+
+    # We shouldn't need to check for more specific output than this.
+    expected_output_strings = [
+        "Configuring project for deployment...\nLogging run of `manage.py deploy`...",
+        "Deployment target: Fly.io\n  Using plugin: dsd_flyio",
+         "--- Your project is now configured for deployment on Fly.io ---",
+         "You can find a full record of this configuration in the dsd_logs directory.",
+    ]
+
+    for expected_string in expected_output_strings:
+        assert expected_string in stdout
+
+
+

--- a/tests/integration_tests/platform_agnostic_tests/test_console_output.py
+++ b/tests/integration_tests/platform_agnostic_tests/test_console_output.py
@@ -47,8 +47,7 @@ def test_standard_output(tmp_project):
          "You can find a full record of this configuration in the dsd_logs directory.",
     ]
 
+    # Make sure output is not doubled (ie logging written to log and stdout).
     for expected_string in expected_output_strings:
         assert expected_string in stdout
-
-
-
+        assert stdout.count(expected_string) == 1

--- a/tests/integration_tests/platform_agnostic_tests/test_console_output.py
+++ b/tests/integration_tests/platform_agnostic_tests/test_console_output.py
@@ -52,15 +52,18 @@ def test_standard_output(tmp_project):
         assert expected_string in stdout
         assert stdout.count(expected_string) == 1
 
-@pytest.mark.skip("Needs more config to test behavior correctly.")
 def test_logging_streaming_to_stdout(tmp_project):
     """Test that output is not doubled when logging is configured to stream to stdout.
 
-    DEV: The interaction between pytest, logging, and stdout is more complex than this
-    test currently represents. To actually detect doubled output, this test needs to 
+    DEV: The interaction between pytest, logging, and stdout is fairly complex.
+
+    To actually detect doubled output, this test would probably need to 
     intercept the logging stream that pytest captures as well as stdout. That doesn't seem
-    worthwhile at the moment. If there are more issues with doubled output, we can revisit
-    this.
+    worthwhile at the moment.
+
+    Instead, we'll just check that pytest doesn't see any stdout when logging streams
+    to stdout. Pytest grabs the log stream so we don't see it here, but the user should
+    see that stream.
     """
     # For now, this test only works if the dsd-flyio plugin is being tested.
     # Skip if that's not available.
@@ -86,15 +89,5 @@ def test_logging_streaming_to_stdout(tmp_project):
     dsd_command = "python manage.py deploy"
     stdout, stderr = msp.call_deploy(tmp_project, dsd_command)
 
-    # We shouldn't need to check for more specific output than this.
-    expected_output_strings = [
-        "Configuring project for deployment...\nLogging run of `manage.py deploy`...",
-        "Deployment target: Fly.io\n  Using plugin: dsd_flyio",
-         "--- Your project is now configured for deployment on Fly.io ---",
-         "You can find a full record of this configuration in the dsd_logs directory.",
-    ]
-
-    # Make sure output is not doubled (ie logging written to log and stdout).
-    for expected_string in expected_output_strings:
-        assert expected_string in stdout
-        assert stdout.count(expected_string) == 1
+    # We shouldn't see anything in stdout, in the testing environment.
+    assert not stdout


### PR DESCRIPTION
A contributor at DjangoCon US 2025 sprints ran deploy against a project that was configured to have logging stream to stdout. They saw doubled output of most info that's written to the console; once from the print to stdout that write_output() does, and once from the log stream.

This PR updates write_output() to check if logging streams to stdout or stderr before printing to the console.