### PR TITLE
Custom e2e args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ For inspiration and motivation, see [Keep a CHANGELOG](https://keepachangelog.co
 
 This release will have a stable public interface for end users, and for plugin developers as well. The project will continue to be refined internally and may gain some new features, but will have overall stability as a high priority.
 
+### (Unreleased)
+
+#### External changes
+
+- N/A
+
+#### Internal changes
+
+- When running e2e tests, the `--plugin-args-string` argument can be used to pass plugin-specific CLI args for the e2e `deploy` call. ie `$ pytest tests/e2e_tests --plugin dsd_flyio -s --plugin-args-string "--vm-size shared-cpu-2x"`.
+
 ### 1.2.1
 
 #### External changes

--- a/tests/e2e_tests/conftest.py
+++ b/tests/e2e_tests/conftest.py
@@ -77,6 +77,12 @@ def pytest_addoption(parser):
         default=False,
         help="Skip all confirmations",
     )
+    parser.addoption(
+        "--plugin-args-string",
+        action="store",
+        default="",
+        help="Custom plugin-specific CLI args to include in the deploy call.",
+    )
     # parser.addoption(
     #     "--plugin",
     #     action="store",

--- a/tests/e2e_tests/conftest.py
+++ b/tests/e2e_tests/conftest.py
@@ -94,13 +94,14 @@ def pytest_addoption(parser):
 # Bundle these options into a single object.
 class CLIOptions:
     def __init__(
-        self, pkg_manager, pypi, automate_all, skip_confirmations, plugin_name
+        self, pkg_manager, pypi, automate_all, skip_confirmations, plugin_name, plugin_args_string, 
     ):
         self.pkg_manager = pkg_manager
         self.pypi = pypi
         self.automate_all = automate_all
         self.skip_confirmations = skip_confirmations
         self.plugin_name = plugin_name
+        self.plugin_args_string = plugin_args_string
 
 
 @pytest.fixture(scope="session")
@@ -111,6 +112,7 @@ def cli_options(request):
         automate_all=request.config.getoption("--automate-all"),
         skip_confirmations=request.config.getoption("--skip-confirmations"),
         plugin_name=request.config.getoption("--plugin"),
+        plugin_args_string=request.config.getoption("--plugin-args-string")
     )
 
 

--- a/tests/e2e_tests/utils/it_helper_functions.py
+++ b/tests/e2e_tests/utils/it_helper_functions.py
@@ -47,13 +47,13 @@ def get_python_exe(tmp_project):
     return python_exe.as_posix()
 
 
-def run_simple_deploy(python_cmd, platform="", automate_all=False):
+def run_simple_deploy(python_cmd, platform="", automate_all=False, plugin_args_string=""):
     """Run deploy against the test project."""
     print("Running manage.py deploy...")
     if automate_all:
-        make_sp_call(f"{python_cmd} manage.py deploy --automate-all --e2e-testing")
+        make_sp_call(f"{python_cmd} manage.py deploy --automate-all --e2e-testing {plugin_args_string}")
     else:
-        make_sp_call(f"{python_cmd} manage.py deploy --e2e-testing")
+        make_sp_call(f"{python_cmd} manage.py deploy --e2e-testing {plugin_args_string} ")
 
 
 def commit_configuration_changes():


### PR DESCRIPTION
Add a --plugin-args-string option when running e2e tests. This allows customizing the `deploy` call when running e2e tests, to test specific sets of CLI args.

Example:

```sh
$ pytest tests/e2e_tests --plugin dsd_flyio -s --plugin-args-string "--vm-size shared-cpu-2x"
```