### PR TITLE
Support nanodjango projects

### DIFF
--- a/django_simple_deploy/management/commands/deploy.py
+++ b/django_simple_deploy/management/commands/deploy.py
@@ -442,6 +442,12 @@ class Command(BaseCommand):
         if wagtail_path.exists():
             return wagtail_path
 
+        # Don't reject nanodjango projects.
+        # nanodjango doesn't use a traditional settings.py file. If we detect nanodjango,
+        # return None without raising an error.
+        if sys.argv[0].endswith("nanodjango"):
+            return None
+
         # Can't identify a settings path, so we need to bail.
         error_msg = f"Couldn't find a settings file. Tried {standard_path.as_posix()} and {wagtail_path.as_posix()}"
         raise DSDCommandError(error_msg)

--- a/django_simple_deploy/management/commands/deploy.py
+++ b/django_simple_deploy/management/commands/deploy.py
@@ -448,6 +448,7 @@ class Command(BaseCommand):
         if sys.argv[0].endswith("nanodjango"):
             # This is the first place we detect this, so set dsd_config.nanodjango_project here.
             dsd_config.nanodjango_project = True
+            dsd_config.nanodjango_script = sys.argv[2]
             return None
 
         # Can't identify a settings path, so we need to bail.

--- a/django_simple_deploy/management/commands/deploy.py
+++ b/django_simple_deploy/management/commands/deploy.py
@@ -446,6 +446,8 @@ class Command(BaseCommand):
         # nanodjango doesn't use a traditional settings.py file. If we detect nanodjango,
         # return None without raising an error.
         if sys.argv[0].endswith("nanodjango"):
+            # This is the first place we detect this, so set dsd_config.nanodjango_project here.
+            dsd_config.nanodjango_project = True
             return None
 
         # Can't identify a settings path, so we need to bail.

--- a/django_simple_deploy/management/commands/utils/dsd_config.py
+++ b/django_simple_deploy/management/commands/utils/dsd_config.py
@@ -31,6 +31,7 @@ class DSDConfig:
         self.pkg_manager = ""
         self.requirements = None
         self.nested_project = None
+        self.nanodjango_project = None
 
         # Paths in user's local project.
         self.project_root = None
@@ -70,7 +71,7 @@ class DSDConfig:
             msg = "Could not identify project's root directory."
             raise DSDCommandError(msg)
 
-        if self.settings_path is None:
+        if self.settings_path is None and not self.nanodjango_project:
             msg = "Could not identify path to settings.py."
             raise DSDCommandError(msg)
 

--- a/django_simple_deploy/management/commands/utils/dsd_config.py
+++ b/django_simple_deploy/management/commands/utils/dsd_config.py
@@ -32,6 +32,7 @@ class DSDConfig:
         self.requirements = None
         self.nested_project = None
         self.nanodjango_project = None
+        self.nanodjango_script = None
 
         # Paths in user's local project.
         self.project_root = None


### PR DESCRIPTION
Supporting nanodjango projects from core django-simple-deploy really means:

- Don't reject a project just because it doesn't conform to standard Django project structure.
- If it doesn't conform, and we find a nanodjango signature, add information to dsd_config that will help nanodjango-focused plugins.