### PR TITLE
Don't require Poetry or Pipenv for integration testing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ For inspiration and motivation, see [Keep a CHANGELOG](https://keepachangelog.co
 
 This release will have a stable public interface for end users, and for plugin developers as well. The project will continue to be refined internally and may gain some new features, but will have overall stability as a high priority.
 
+### (Unreleased)
+
+#### External changes
+
+- N/A
+
+#### Internal changes
+
+- No longer requires Poetry or Pipenv to run base set of integration tests.
+
 ### 1.3.0
 
 #### External changes

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -90,8 +90,6 @@ def pytest_sessionfinish(session, exitstatus):
 def check_prerequisites(pytestconfig):
     """Make sure dev environment supports integration tests."""
     ihf.check_plugin_available(pytestconfig)
-    # ihf.check_package_manager_available("poetry")
-    ihf.check_package_manager_available("pipenv")
 
 
 @pytest.fixture(scope="session")
@@ -124,11 +122,9 @@ def tmp_project(tmp_path_factory, pytestconfig):
     # Return the location of the temp project.
     return tmp_proj_dir
 
-
-# @pytest.fixture(scope="module", params=["req_txt", "poetry", "pipenv"])
-# pkg_managers = ["poetry"]
-# pkg_managers = ["req_txt", "poetry", "pipenv"]
-
+# Determine which package managers to reset sample project for.
+# If available, we'll test for a requirements.txt-based workflow, a Poetry
+# workflow, and a Pipenv workflow.
 pkg_managers = ["req_txt"]
 if ihf.check_package_manager_available("poetry"):
     pkg_managers.append("poetry")

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -90,7 +90,7 @@ def pytest_sessionfinish(session, exitstatus):
 def check_prerequisites(pytestconfig):
     """Make sure dev environment supports integration tests."""
     ihf.check_plugin_available(pytestconfig)
-    ihf.check_package_manager_available("poetry")
+    # ihf.check_package_manager_available("poetry")
     ihf.check_package_manager_available("pipenv")
 
 
@@ -125,7 +125,17 @@ def tmp_project(tmp_path_factory, pytestconfig):
     return tmp_proj_dir
 
 
-@pytest.fixture(scope="module", params=["req_txt", "poetry", "pipenv"])
+# @pytest.fixture(scope="module", params=["req_txt", "poetry", "pipenv"])
+# pkg_managers = ["poetry"]
+# pkg_managers = ["req_txt", "poetry", "pipenv"]
+
+pkg_managers = ["req_txt"]
+if ihf.check_package_manager_available("poetry"):
+    pkg_managers.append("poetry")
+if ihf.check_package_manager_available("pipenv"):
+    pkg_managers.append("pipenv")
+
+@pytest.fixture(scope="module", params=pkg_managers)
 def reset_test_project(request, tmp_project):
     """Reset the test project, so it can be used again by another test module,
     which may be another platform.

--- a/tests/integration_tests/utils/it_helper_functions.py
+++ b/tests/integration_tests/utils/it_helper_functions.py
@@ -126,11 +126,7 @@ def check_package_manager_available(pkg_manager):
     else:
         msg = dedent(
             f"""
-        --- You must have {pkg_manager.title()} installed in order to run integration tests. ---
-
-        If you have a strong reason not to install {pkg_manager.title()}, please open an issue
-        and share your reasoning. We can look at installing {pkg_manager.title()} to the test
-        environment each time a test is run.
+        --- To run the full set of tests, {pkg_manager.title()} should be installed. ---
 
         Instructions for installing {pkg_manager.title()} can be found here:
         """
@@ -141,4 +137,4 @@ def check_package_manager_available(pkg_manager):
         elif pkg_manager == "pipenv":
             msg += "https://pipenv.pypa.io/en/latest/install/#installing-pipenv"
 
-        pytest.exit(msg)
+        print(msg)

--- a/tests/integration_tests/utils/it_helper_functions.py
+++ b/tests/integration_tests/utils/it_helper_functions.py
@@ -138,3 +138,5 @@ def check_package_manager_available(pkg_manager):
             msg += "  https://pipenv.pypa.io/en/latest/install/#installing-pipenv\n"
 
         print(msg)
+
+        return False

--- a/tests/integration_tests/utils/it_helper_functions.py
+++ b/tests/integration_tests/utils/it_helper_functions.py
@@ -126,15 +126,15 @@ def check_package_manager_available(pkg_manager):
     else:
         msg = dedent(
             f"""
-        --- To run the full set of tests, {pkg_manager.title()} should be installed. ---
 
-        Instructions for installing {pkg_manager.title()} can be found here:
+        --- To run the full set of tests, {pkg_manager.title()} should be installed. ---
+          Instructions for installing {pkg_manager.title()} can be found here:
         """
         )
 
         if pkg_manager == "poetry":
-            msg += "https://python-poetry.org/docs/#installation"
+            msg += "  https://python-poetry.org/docs/#installation\n"
         elif pkg_manager == "pipenv":
-            msg += "https://pipenv.pypa.io/en/latest/install/#installing-pipenv"
+            msg += "  https://pipenv.pypa.io/en/latest/install/#installing-pipenv\n"
 
         print(msg)


### PR DESCRIPTION
Continue to use them when available, but don't require them when running integration tests.